### PR TITLE
feat: expose programmatic api

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ npx esbuild-jest [...optional-jest-arguments]
 
 You can pass any Jest arguments just like you're running Jest itself.
 
+### Advanced Usage
+
+You can also use the CLI programmatically – especially useful if you are wrapping it in a custom script:
+
+```js
+import { build } from 'esbuild-jest-cli';
+import myPlugin from './my-esbuild-plugin.js';
+
+await build({
+  esbuild: {
+    outdir: 'dist',
+    sourcemap: true,
+    plugins: [myPlugin()],
+  },
+  package: {
+    name: 'custom-name',
+  },
+});
+```
+
 Configuration
 -------------
 
@@ -103,6 +123,19 @@ In the `esbuild` section, you can override any `esbuild` option except for a few
 Any other valid [esbuild configuration options](https://esbuild.github.io/api/#options) are supported as expected.
 
 In `package` section, you can override fields in the generated `package.json`, such as `name`, `scripts`, etc.
+It is also possible to pass a function which to modify its contents, e.g.:
+
+```js
+module.exports = {
+  esbuild: {
+    // ...
+  },
+  package: (p) => ({
+    ...p,
+    customField: 'customValue',
+  }),
+};
+```
 
 Troubleshooting
 ---------------

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ In the `esbuild` section, you can override any `esbuild` option except for a few
 Any other valid [esbuild configuration options](https://esbuild.github.io/api/#options) are supported as expected.
 
 In `package` section, you can override fields in the generated `package.json`, such as `name`, `scripts`, etc.
-It is also possible to pass a function which to modify its contents, e.g.:
+It is also possible to pass a function to modify its contents, e.g.:
 
 ```js
 module.exports = {

--- a/build.mjs
+++ b/build.mjs
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
+import { cosmiconfig } from 'cosmiconfig';
 import { build } from './index.mjs';
 
 try {
-  await build();
+  const explorer = cosmiconfig('esbuild-jest');
+  const esbuildJestBaseConfig = await explorer.search();
+  await build(esbuildJestBaseConfig.config);
 } catch (e) {
-  console.error(`${e}`);
+  console.error(`${e.stack || e}`);
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/wix-incubator/esbuild-jest-cli#readme",
   "dependencies": {
     "cosmiconfig": "^8.1.3",
+    "lodash.merge": "^4.6.2",
     "esbuild": "^0.17.4",
     "import-from": "^4.0.0",
     "resolve-from": "^5.0.0"


### PR DESCRIPTION
Allows to call build programmatically with predefined configs (`cosmiconfig` is not being used in this scenario):

```js
import { build } from 'esbuild-jest-cli';

await build({
  ...customOptions
});
```