### PR TITLE
fix: prevent shim leakage in Jest 28+

### DIFF
--- a/__fixtures__/simple-project/src/entry1.test.js
+++ b/__fixtures__/simple-project/src/entry1.test.js
@@ -1,4 +1,4 @@
 const { hello } = require('./utils');
 
-test('hello', () => expect('hello').toBe('hello'));
+test('hello', () => expect(hello()).toBe('hello'));
 

--- a/__fixtures__/simple-project/src/entry2.test.js
+++ b/__fixtures__/simple-project/src/entry2.test.js
@@ -1,4 +1,4 @@
 const { world } = require('./utils');
 
-test('world', () => expect('world').toBe('world'));
+test('world', () => expect(world()).toBe('world'));
 

--- a/__fixtures__/simple-project/src/utils.js
+++ b/__fixtures__/simple-project/src/utils.js
@@ -1,6 +1,8 @@
+const { cyan } = require('chalk');
+
 function hello() { return 'hello'; }
 function world() { return 'world'; }
 
-function globalize(s) { return 'global ' + s; }
+function globalize(s) { return cyan('global') + ' ' + s; }
 
 module.exports = { hello, world, globalize };

--- a/utils/esmRequireShim.mjs
+++ b/utils/esmRequireShim.mjs
@@ -4,14 +4,8 @@ import { dirname as esbuild_jest_cli__dirname } from "path";
 import { fileURLToPath as esbuild_jest_cli__fileURLToPath } from "url";
 import esbuild_jest_cli__module from "module";
 
-if (typeof globalThis.__filename === "undefined") {
-  globalThis.__filename = esbuild_jest_cli__fileURLToPath(import.meta.url);
-}
-if (typeof globalThis.__dirname === "undefined") {
-  globalThis.__dirname = esbuild_jest_cli__dirname(globalThis.__filename);
-}
-if (typeof globalThis.require === "undefined") {
-  globalThis.require = esbuild_jest_cli__module.createRequire(import.meta.url);
-}
+var __filename = esbuild_jest_cli__fileURLToPath(import.meta.url);
+var __dirname = esbuild_jest_cli__dirname(__filename);
+var require = esbuild_jest_cli__module.createRequire(import.meta.url);
 /* End CommonJS shim */
 `;


### PR DESCRIPTION
This pull request fixes the approach used `utils/esmRequireShim.mjs` due to a recently discovered issue: https://github.com/facebook/jest/issues/14086 

Seems that the initial idea to use lazy initialization for `__filename`, `__dirname`, `require` is dangerous as it causes the leakage of an unsandboxed `require` causing strict equality (`===` and `!==`) and other issues.