### PR TITLE
fix: bundle external entry points

### DIFF
--- a/__fixtures__/simple-project/jest.config.js
+++ b/__fixtures__/simple-project/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   globalSetup: '<rootDir>/globalSetup',
   globalTeardown: '<rootDir>/globalTeardown',
+  setupFilesAfterEnv: ['lodash/noop'],
   testMatch: [
     '<rootDir>/src/**/*.test.js',
   ]

--- a/utils/move-file.mjs
+++ b/utils/move-file.mjs
@@ -1,0 +1,17 @@
+import { access, mkdir, rename } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export async function moveFile(source, destination) {
+  try {
+    const targetDir = dirname(destination);
+    try {
+      await access(targetDir);
+    } catch {
+      await mkdir(targetDir, { recursive: true });
+    }
+
+    await rename(source, destination);
+  } catch (error) {
+    throw error;
+  }
+}


### PR DESCRIPTION
Fixes problems in Jest config where, for example, `setupFilesAfterEnv` relies on external node_modules.

I created a simple test:

```diff
 module.exports = {
   globalSetup: '<rootDir>/globalSetup',
   globalTeardown: '<rootDir>/globalTeardown',
+  setupFilesAfterEnv: ['lodash/noop'],
   testMatch: [
     '<rootDir>/src/**/*.test.js',
   ]
```

With this fix, `noop` goes to `bundled_externals` directory inside the bundle, and the tests run correctly.