### PR TITLE
feat: remove esbuild-jest-patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,6 @@ or with yarn:
 yarn add --dev esbuild-jest-cli
 ```
 
-Before you can use it, you also have to run `esbuild-jest-patch`, which comes with the package, e.g.:
-
-```
-npx esbuild-jest-patch
-```
-
-This patch adds an additional module to the exports section in the jest-cli package. It is mandatory for proper usage.
-
 Usage
 -----
 

--- a/__fixtures__/simple-project/package.json
+++ b/__fixtures__/simple-project/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "prepare": "esbuild-jest-patch",
     "build": "esbuild-jest",
     "test": "jest"
   },

--- a/utils/patch-jest.mjs
+++ b/utils/patch-jest.mjs
@@ -1,21 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import { resolveModuleViaChain } from "./resolve-via-chain.mjs";
+const yellow = '\x1b[33m';
+const reset = '\x1b[0m';
 
-export default function patchJest(rootDir) {
-    const manifestPath = resolveModuleViaChain(rootDir, ['jest'], 'jest-cli/package.json');
-    if (!manifestPath) {
-      return;
-    }
-
-  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  if (!manifest.exports['./run']) {
-    const majorVersion = parseInt(manifest.version.split('.', 1)[0], 10);
-    manifest.exports['./run'] = majorVersion < 29 ? './build/cli/index.js' : './build/run.js';
-    const newManifestRaw = JSON.stringify(manifest, null, 2) + '\n';
-    writeFileSync(manifestPath, newManifestRaw);
-  }
-}
-
-patchJest(process.cwd());
+console.warn(yellow + '[esbuild-jest-patch] This tool is deprecated, you no longer need to use it.' + reset);

--- a/utils/resolve-via-chain.mjs
+++ b/utils/resolve-via-chain.mjs
@@ -11,6 +11,10 @@ export function importViaChain(rootDir, chain, targetModuleName) {
   return importFrom(resolveCwd(rootDir, chain), targetModuleName);
 }
 
+export function importViaChainUnsafe(rootDir, chain, targetFilename) {
+  return importFrom(rootDir, path.join(resolveCwd(rootDir, chain), targetFilename));
+}
+
 function resolveCwd(rootDir, chain) {
   let cwd = rootDir;
   for (const module of chain) {


### PR DESCRIPTION
No need for the patching stage, as we can import the module in "unsafe" mode directly.