### PR TITLE
feat: add basic logging

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 import { cosmiconfig } from 'cosmiconfig';
+import { logger } from './utils/logger.mjs';
 import { build } from './index.mjs';
 
 try {
   const explorer = cosmiconfig('esbuild-jest');
   const esbuildJestBaseConfig = await explorer.search();
-  await build(esbuildJestBaseConfig.config);
+  await logger.trace.complete(esbuildJestBaseConfig, 'esbuild-jest-cli', () => build(esbuildJestBaseConfig.config));
 } catch (e) {
   console.error(`${e.stack || e}`);
   process.exit(1);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   },
   "homepage": "https://github.com/wix-incubator/esbuild-jest-cli#readme",
   "dependencies": {
+    "bunyamin": "^1.5.1",
+    "bunyan": "^2.0.0",
+    "bunyan-debug-stream": "^3.1.0",
     "cosmiconfig": "^8.1.3",
     "lodash.merge": "^4.6.2",
     "import-from": "^4.0.0",

--- a/utils/logger.mjs
+++ b/utils/logger.mjs
@@ -1,0 +1,81 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  bunyamin,
+  isDebug,
+  threadGroups,
+  traceEventStream,
+} from 'bunyamin';
+import { createLogger } from 'bunyan';
+import { create as createDebugStream } from 'bunyan-debug-stream';
+
+const PACKAGE_NAME = 'esbuild-jest-cli';
+
+threadGroups.add({
+  id: PACKAGE_NAME,
+  displayName: PACKAGE_NAME,
+});
+
+threadGroups.add({
+  id: 'jest-transform',
+  displayName: 'Jest Transform',
+});
+
+bunyamin.useLogger(createBunyanImpl(), 1);
+
+export const logger = bunyamin.child({
+  cat: PACKAGE_NAME,
+});
+
+const noop = () => {};
+
+export const optimizeTracing = isDebug(PACKAGE_NAME)
+  ? ((f) => f)
+  : (() => noop);
+
+function createBunyanImpl() {
+  const logPath = process.env.BUNYAMIN_LOG;
+
+  return createLogger({
+    name: PACKAGE_NAME,
+    streams: [
+      {
+        type: 'raw',
+        level: 'warn',
+        stream: createDebugStream({
+          out: process.stderr,
+          showMetadata: false,
+          showDate: false,
+          showPid: false,
+          showProcess: false,
+          showLoggerName: false,
+          showLevel: false,
+          prefixers: {
+            cat: (value) => String(value).split(',', 1)[0],
+          },
+        }),
+      },
+      ...(logPath
+        ? [
+          {
+            type: 'raw',
+            level: 'trace',
+            stream: traceEventStream({
+              filePath: ensureCleanLog(logPath),
+              threadGroups,
+            }),
+          },
+        ]
+        : []),
+    ],
+  });
+}
+
+function ensureCleanLog(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+
+  return filePath;
+}


### PR DESCRIPTION
Added basic logging support. To enable logs:

```
BUNYAMIN_LOG=/path/to/log.txt esbuild-jest-cli ...
```

To enable trace logs:

```
DEBUG=esbuild-jest-cli BUNYAMIN_LOG=/path/to/log.txt esbuild-jest-cli ...
```

The logs can be viewed via [Perfetto UI](https://ui.perfetto.dev) or `chrome://tracing`.

![image](https://github.com/wix-incubator/esbuild-jest-cli/assets/1962469/345b2f0a-0ec6-4cfd-955b-2e357f633b28)
