### PR TITLE
fix: logger trace mode issues

### DIFF
--- a/utils/logger.mjs
+++ b/utils/logger.mjs
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
   bunyamin,
+  nobunyamin,
   isDebug,
   threadGroups,
   traceEventStream,
@@ -19,13 +20,15 @@ threadGroups.add({
 threadGroups.add({
   id: 'jest-transform',
   displayName: 'Jest Transform',
+  maxConcurrency: 100500,
 });
 
 bunyamin.useLogger(createBunyanImpl(), 1);
 
-export const logger = bunyamin.child({
-  cat: PACKAGE_NAME,
-});
+export const logger = bunyamin.child({ tid: PACKAGE_NAME });
+export const optimizedLogger = isDebug(PACKAGE_NAME)
+  ? logger
+  : nobunyamin;
 
 const noop = () => {};
 


### PR DESCRIPTION
Since the logger has been noisier than expected even outside of `trace` mode, I had to add an `optimizedLogger` counterpart, which makes it much easier to run performance-safe `log.trace.complete(msg, callback)` functions.

Also, surprisingly, the thread concurrency turned out to be really huge, so I had to raise `maxConcurrency` to the maximum possible number (`bunyamin` allows 100,500, but this should be increased to 1,000,000 in the future).