### PR TITLE
fix: linked modules paths

### DIFF
--- a/__fixtures__/linked-local-reporter/index.js
+++ b/__fixtures__/linked-local-reporter/index.js
@@ -1,0 +1,1 @@
+module.exports = class LinkedReporter {};

--- a/__fixtures__/linked-local-reporter/package.json
+++ b/__fixtures__/linked-local-reporter/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "linked-local-reporter",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true
+}

--- a/__fixtures__/simple-project/jest.config.js
+++ b/__fixtures__/simple-project/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   setupFilesAfterEnv: ['lodash/noop'],
   reporters: [
     'default',
+    'linked-local-reporter',
     '<rootDir>/customReporter.js',
   ],
   testMatch: [

--- a/__fixtures__/simple-project/package.json
+++ b/__fixtures__/simple-project/package.json
@@ -13,6 +13,7 @@
     "jest": "^29.5.0",
     "jest-environment-emit": "^1.0.3",
     "jest-allure2-reporter": "^2.0.0-beta.1",
+    "linked-local-reporter": "../linked-local-reporter",
     "lodash": "^4.17.21"
   }
 }

--- a/utils/map-inputs-outputs.mjs
+++ b/utils/map-inputs-outputs.mjs
@@ -12,7 +12,7 @@ export function mapSourceToOutputFiles({ rootDir, outdir, sourceFiles, outputFil
   const outputMap = outputFiles.reduce((acc, rawOutputFile) => {
     const outputFile = path.relative(outdir, rawOutputFile);
     const outputFileParts = outputFile.split('.');
-    const outputFileBase = outputFileParts.slice(0, -1).join('.');
+    const outputFileBase = adaptTwoDots(outputFileParts.slice(0, -1).join('.'));
     acc[outputFileBase] = rawOutputFile;
     return acc;
   }, {});
@@ -27,4 +27,14 @@ export function mapSourceToOutputFiles({ rootDir, outdir, sourceFiles, outputFil
   }
 
   return result;
+}
+
+function adaptTwoDots(filePath) {
+  const segments = filePath.split(path.sep);
+  return segments.map(convertTwoDots).join(path.sep);
+}
+
+function convertTwoDots(segment) {
+  return segment === '_.._' ? '..' : segment;
+
 }


### PR DESCRIPTION
It turned out that ESBuild creates `_.._` folders in the output for files resolved as `..`.

So, this fix adjusts our source-output key mapping logic to make sure they don't get ignored while resolving the final Jest config. Otherwise, the paths are going to be incorrect. 🤷‍♂️ 