### PR TITLE
fix: relative coverage directory

### DIFF
--- a/__fixtures__/simple-project/verify.js
+++ b/__fixtures__/simple-project/verify.js
@@ -29,8 +29,9 @@ function verifyDirectoryStructure() {
 }
 
 function verifyJestConfig() {
-  const { globalSetup, reporters, setupFilesAfterEnv, testEnvironment, testMatch, testRunner, globalTeardown } = parseJSON('jest.config.json');
+  const { coverageDirectory, globalSetup, reporters, setupFilesAfterEnv, testEnvironment, testMatch, testRunner, globalTeardown } = parseJSON('jest.config.json');
 
+  assertEqual(coverageDirectory, '<rootDir>/coverage', 'coverageDirectory');
   assertEqual(globalSetup, '<rootDir>/globalSetup.mjs', 'globalSetup');
   assertEqual(reporters.length, 4, 'reporters length');
   assertEqual(reporters[0][0], 'default', 'reporters[0]');

--- a/plugin.mjs
+++ b/plugin.mjs
@@ -149,6 +149,7 @@ export default ({
           ...projectConfig,
           cacheDirectory: undefined,
           cwd: undefined,
+          coverageDirectory: mapFile(projectConfig.coverageDirectory),
           globalSetup: mapFile(projectConfig.globalSetup),
           globalTeardown: mapFile(projectConfig.globalTeardown),
           id: undefined,


### PR DESCRIPTION
The coverage directory must be a non-absolute path — otherwise, the bundles will be not portable.