### PR TITLE
fix: linked module resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Bundle project
         run: npm run build
         working-directory: __fixtures__/simple-project
+      - name: Verify the bundle
+        run: npm run verify
+        working-directory: __fixtures__/simple-project
       - name: Set up bundled project
         uses: bahmutov/npm-install@v1
         with:

--- a/__fixtures__/linked-dependencies/bundled/package.json
+++ b/__fixtures__/linked-dependencies/bundled/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@linked-dependencies/bundled",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true,
+  "exports": {
+    "./reporter": "./reporters/default.js"
+  }
+}

--- a/__fixtures__/linked-dependencies/bundled/reporters/default.js
+++ b/__fixtures__/linked-dependencies/bundled/reporters/default.js
@@ -1,0 +1,1 @@
+module.exports = class LinkedLocalReporter {};

--- a/__fixtures__/linked-dependencies/external/package.json
+++ b/__fixtures__/linked-dependencies/external/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@linked-dependencies/external",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true,
+  "exports": {
+    "./reporter": "./reporters/default.js"
+  }
+}

--- a/__fixtures__/linked-dependencies/external/reporters/default.js
+++ b/__fixtures__/linked-dependencies/external/reporters/default.js
@@ -1,0 +1,1 @@
+module.exports = class LinkedExternalReporter {};

--- a/__fixtures__/linked-local-reporter/index.js
+++ b/__fixtures__/linked-local-reporter/index.js
@@ -1,1 +1,0 @@
-module.exports = class LinkedReporter {};

--- a/__fixtures__/linked-local-reporter/package.json
+++ b/__fixtures__/linked-local-reporter/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "linked-local-reporter",
-  "version": "1.0.0",
-  "main": "index.js",
-  "private": true
-}

--- a/__fixtures__/simple-project/.esbuild-jestrc.js
+++ b/__fixtures__/simple-project/.esbuild-jestrc.js
@@ -6,7 +6,7 @@ module.exports = {
     "outExtension": {
       ".js": ".mjs"
     },
-    "external": ["chalk", "dtrace-provider"],
+    "external": ["chalk", "dtrace-provider", "@linked-dependencies/external"],
   },
   "preTransform": (path, contents) => {
     if (path.includes('lodash/noop')) {
@@ -16,6 +16,9 @@ module.exports = {
     return contents;
   },
   "package": {
-    "name": "custom-name"
+    "name": "custom-name",
+    "dependencies": {
+      "@linked-dependencies/external": "../linked-dependencies/external",
+    }
   }
 };

--- a/__fixtures__/simple-project/jest.config.js
+++ b/__fixtures__/simple-project/jest.config.js
@@ -5,7 +5,8 @@ module.exports = {
   setupFilesAfterEnv: ['lodash/noop'],
   reporters: [
     'default',
-    'linked-local-reporter',
+    '@linked-dependencies/bundled/reporter',
+    '@linked-dependencies/external/reporter',
     '<rootDir>/customReporter.js',
   ],
   testMatch: [

--- a/__fixtures__/simple-project/package.json
+++ b/__fixtures__/simple-project/package.json
@@ -5,15 +5,17 @@
   "main": "index.js",
   "scripts": {
     "build": "esbuild-jest",
-    "test": "jest"
+    "test": "jest",
+    "verify": "node verify.js"
   },
   "devDependencies": {
+    "@linked-dependencies/bundled": "../linked-dependencies/bundled",
+    "@linked-dependencies/external": "../linked-dependencies/external",
     "esbuild": "^0.19.8",
     "esbuild-jest-cli": "../..",
     "jest": "^29.5.0",
     "jest-environment-emit": "^1.0.3",
     "jest-allure2-reporter": "^2.0.0-beta.1",
-    "linked-local-reporter": "../linked-local-reporter",
     "lodash": "^4.17.21"
   }
 }

--- a/__fixtures__/simple-project/verify.js
+++ b/__fixtures__/simple-project/verify.js
@@ -1,0 +1,64 @@
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const rootDir = path.join(__dirname, '..', 'simple-project-bundled');
+
+main();
+
+function main() {
+  console.log('Verifying that the bundled project is correct...');
+  verifyDirectoryStructure();
+  verifyJestConfig();
+  console.log('Success!');
+}
+
+function verifyDirectoryStructure() {
+  assertExists('package.json');
+  assertExists('jest.config.json');
+  assertExists('globalSetup.mjs');
+  assertExists('globalTeardown.mjs');
+  assertExists('customReporter.mjs');
+  assertExists('src/entry1.test.mjs');
+  assertExists('src/entry2.test.mjs');
+  assertExists('_.._/linked-dependencies/bundled/reporters/default.mjs');
+  assertExists('bundled_externals/jest-environment-emit/node.mjs');
+  assertExists('bundled_externals/lodash/noop.mjs');
+  assertDoesNotExist('node_modules');
+  assertDoesNotExist('_.._/linked-dependencies/external');
+}
+
+function verifyJestConfig() {
+  const { globalSetup, reporters, setupFilesAfterEnv, testEnvironment, testMatch, testRunner, globalTeardown } = parseJSON('jest.config.json');
+
+  assertEqual(globalSetup, '<rootDir>/globalSetup.mjs', 'globalSetup');
+  assertEqual(reporters.length, 4, 'reporters length');
+  assertEqual(reporters[0][0], 'default', 'reporters[0]');
+  assertEqual(reporters[1][0], '<rootDir>/_.._/linked-dependencies/bundled/reporters/default.mjs', 'reporters[1]');
+  assertEqual(reporters[2][0], '@linked-dependencies/external/reporter', 'reporters[2]');
+  assertEqual(reporters[3][0], '<rootDir>/customReporter.mjs', 'reporters[3]');
+  assertEqual(setupFilesAfterEnv.length, 1, 'setupFilesAfterEnv.length');
+  assertEqual(setupFilesAfterEnv[0], '<rootDir>/bundled_externals/lodash/noop.mjs', 'setupFilesAfterEnv[0]');
+  assertEqual(testEnvironment, '<rootDir>/bundled_externals/jest-environment-emit/node.mjs', 'testEnvironment');
+  assertEqual(testMatch.length, 2, 'testMatch.length');
+  assertEqual(testMatch[0], '<rootDir>/src/entry1.test.mjs', 'testMatch[0]');
+  assertEqual(testMatch[1], '<rootDir>/src/entry2.test.mjs', 'testMatch[1]');
+  assertEqual(testRunner, 'jest-circus/runner', 'testRunner');
+  assertEqual(globalTeardown, '<rootDir>/globalTeardown.mjs', 'globalTeardown');
+}
+
+function assertExists(fileName) {
+  assert(fs.existsSync(path.join(rootDir, fileName)), `${fileName} should exist`);
+}
+
+function assertDoesNotExist(fileName) {
+  assert(!fs.existsSync(path.join(rootDir, fileName)), `${fileName} should not exist`);
+}
+
+function assertEqual(actual, expected, name) {
+  assert(actual === expected, `${name} should be ${expected}, but was: ${actual}`);
+}
+
+function parseJSON(fileName) {
+  return JSON.parse(fs.readFileSync(path.join(rootDir, fileName), 'utf8'));
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bunyan": "^2.0.0",
     "bunyan-debug-stream": "^3.1.0",
     "cosmiconfig": "^8.1.3",
+    "find-up": "^7.0.0",
     "lodash.merge": "^4.6.2",
     "import-from": "^4.0.0",
     "resolve-from": "^5.0.0"


### PR DESCRIPTION
Fixes an edge case where a scoped module (e.g., `npm link @org/module`) is linked and marked as external.

Adds extra logging and e2e test suite to increase confidence.