### PR TITLE
feat: more flexible transformer mechanism

### DIFF
--- a/index.d.mts
+++ b/index.d.mts
@@ -1,4 +1,5 @@
-import type {BuildOptions} from 'esbuild';
+import type { PluginBuild, BuildOptions } from 'esbuild';
+import type { ScriptTransformer } from '@jest/transform';
 
 export type ESBuildJestConfig = {
   esbuild: Omit<
@@ -12,7 +13,7 @@ export type ESBuildJestConfig = {
     | 'entryPoints'
   >;
   package: Record<string, unknown> | ((base: Record<string, unknown>) => Record<string, unknown>);
-  preTransform: (filePath: string, fileContent: string) => string;
+  useTransformer: (context: { build: PluginBuild; transformer: ScriptTransformer; }) => void | Promise<void>;
   postTransform: (filePath: string, fileContent: string) => string;
 };
 

--- a/index.mjs
+++ b/index.mjs
@@ -17,6 +17,7 @@ const __IS_EXTERNAL__ = optimizeTracing((id, external) => {
   optimizedLogger.trace(`mark as ${external ? 'external' : 'internal'}: ${id}`);
 });
 
+/** @param {import('esbuild-jest-cli').ESBuildJestConfig} esbuildJestConfig */
 export async function build(esbuildJestConfig = {}) {
   const rootDir = process.cwd();
 
@@ -101,8 +102,7 @@ export async function build(esbuildJestConfig = {}) {
         projectConfig,
         tests: tests.map(t => t.path),
         package: wrapPackageMiddleware(esbuildJestConfig.package),
-        preTransform: esbuildJestConfig.preTransform,
-        postTransform: esbuildJestConfig.postTransform,
+        useTransformer: esbuildJestConfig.useTransformer,
       }),
       ...(esbuildBaseConfig.plugins || []),
     ],

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@jest/types": "^29.6.3",
+    "@jest/transform": "^29.6.3",
     "esbuild": "^0.19.8"
   }
 }


### PR DESCRIPTION
## BREAKING CHANGE

Please migrate your `preTransform` and `postTransform` callbacks.

`esbuild-jest-cli` won't be using Jest transformers by default because it is too slow and has to be used sparingly.