### PR TITLE
fix: outer node modules handling

### DIFF
--- a/__fixtures__/simple-project/verify.js
+++ b/__fixtures__/simple-project/verify.js
@@ -22,8 +22,8 @@ function verifyDirectoryStructure() {
   assertExists('src/entry1.test.js');
   assertExists('src/entry2.test.js');
   assertExists('_.._/linked-dependencies/bundled/reporters/default.js');
-  assertExists('bundled_externals/jest-environment-emit/node.js');
-  assertExists('bundled_externals/lodash/noop.js');
+  assertExists('bundled_modules/jest-environment-emit/node.js');
+  assertExists('bundled_modules/lodash/noop.js');
   assertDoesNotExist('node_modules');
   assertDoesNotExist('_.._/linked-dependencies/external');
 }
@@ -39,8 +39,8 @@ function verifyJestConfig() {
   assertEqual(reporters[2][0], '@linked-dependencies/external/reporter', 'reporters[2]');
   assertEqual(reporters[3][0], '<rootDir>/customReporter.js', 'reporters[3]');
   assertEqual(setupFilesAfterEnv.length, 1, 'setupFilesAfterEnv.length');
-  assertEqual(setupFilesAfterEnv[0], '<rootDir>/bundled_externals/lodash/noop.js', 'setupFilesAfterEnv[0]');
-  assertEqual(testEnvironment, '<rootDir>/bundled_externals/jest-environment-emit/node.js', 'testEnvironment');
+  assertEqual(setupFilesAfterEnv[0], '<rootDir>/bundled_modules/lodash/noop.js', 'setupFilesAfterEnv[0]');
+  assertEqual(testEnvironment, '<rootDir>/bundled_modules/jest-environment-emit/node.js', 'testEnvironment');
   assertEqual(testMatch.length, 2, 'testMatch.length');
   assertEqual(testMatch[0], '<rootDir>/src/entry1.test.js', 'testMatch[0]');
   assertEqual(testMatch[1], '<rootDir>/src/entry2.test.js', 'testMatch[1]');

--- a/plugin.mjs
+++ b/plugin.mjs
@@ -1,5 +1,5 @@
 import { writeFile } from 'node:fs/promises';
-import { sep, join, resolve } from 'node:path';
+import { sep, join, relative, resolve } from 'node:path';
 import importFrom from 'import-from';
 import { logger, optimizeTracing } from "./utils/logger.mjs";
 import { convertPathToImport } from "./utils/resolve-module.mjs";
@@ -102,13 +102,9 @@ export default ({
         }
 
         function redirectExternalModule(modulePath) {
+          let replacements = 0;
           const segments = modulePath.split(sep);
-          const nodeModulesIndex = segments.indexOf('node_modules');
-          if (nodeModulesIndex < 0) {
-            return modulePath;
-          }
-
-          return [outdir, 'bundled_externals', ...segments.slice(nodeModulesIndex + 1)].join(sep);
+          return segments.map(x => x === 'node_modules' && replacements++ === 0 ? 'bundled_modules' : x).join(sep);
         }
 
         await moveExternalEntryPointsBackToRoot();

--- a/utils/map-inputs-outputs.mjs
+++ b/utils/map-inputs-outputs.mjs
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 export function mapSourceToOutputFiles({ rootDir, outdir, sourceFiles, outputFiles }) {
-  const sourceMap = sourceFiles.reduce((acc, rawSourceFile) => {
+  const sourcesMap = sourceFiles.reduce((acc, rawSourceFile) => {
     const sourceFile = path.relative(rootDir, rawSourceFile);
     const sourceFileParts = sourceFile.split('.');
     const sourceFileBase = sourceFileParts.slice(0, -1).join('.');
@@ -9,7 +9,7 @@ export function mapSourceToOutputFiles({ rootDir, outdir, sourceFiles, outputFil
     return acc;
   }, {});
 
-  const outputMap = outputFiles.reduce((acc, rawOutputFile) => {
+  const outputsMap = outputFiles.reduce((acc, rawOutputFile) => {
     const outputFile = path.relative(outdir, rawOutputFile);
     const outputFileParts = outputFile.split('.');
     const outputFileBase = adaptTwoDots(outputFileParts.slice(0, -1).join('.'));
@@ -18,10 +18,10 @@ export function mapSourceToOutputFiles({ rootDir, outdir, sourceFiles, outputFil
   }, {});
 
   const result = {};
-  for (const key of Object.keys(sourceMap)) {
-    if (outputMap[key]) {
-      const sourcePath = path.resolve(sourceMap[key]);
-      const outputPath = path.resolve(outputMap[key]);
+  for (const key of Object.keys(sourcesMap)) {
+    if (outputsMap[key]) {
+      const sourcePath = path.resolve(sourcesMap[key]);
+      const outputPath = path.resolve(outputsMap[key]);
       result[sourcePath] = outputPath;
     }
   }


### PR DESCRIPTION
Resolves issue with `node_modules/...` and `../../node_modules/...` path mapping (typical for monorepos).

Earlier, the redirect files could have been moved to a wrong depth which was breaking imports.