### PR TITLE
fix: transform patterns in jest config

### DIFF
--- a/plugin.mjs
+++ b/plugin.mjs
@@ -82,9 +82,8 @@ export default ({
           testMatch: tests.map(mapFile),
           testRunner: mapTestRunner(mapFile(projectConfig.testRunner)),
           transform: {
-            '^(?!node_modules/).+\\.js$': '@swc/jest',
-            '^.+\\.jsx$': '@swc/jest',
-            '^.+\\.tsx?$': '@swc/jest',
+            '^(?!.*node_modules/).+\\.js$': '@swc/jest',
+            '^.+\\.(jsx|tsx?)$': '@swc/jest',
           },
           transformIgnorePatterns: [],
         });


### PR DESCRIPTION
The `'^(?!node_modules/).+\\.js$'` pattern was incorrect leading to excessive transformations, even inside Jest's own files.